### PR TITLE
fix(get): do not panic when no passkey matches the request

### DIFF
--- a/passkeyd/src/cerds/get.rs
+++ b/passkeyd/src/cerds/get.rs
@@ -136,22 +136,26 @@ fn authorization_action(
     passkey_count: usize,
 ) -> AuthorizationAction {
     match (has_another_fido_dev, no_pass, passkey_count) {
-        // no other key, no password
-        // and no credentials either
-        // send the no cerds directly
-        (false, true, 0) => AuthorizationAction::NoCredentials,
+        // no other key and no credentials either,
+        // send the no cerds directly. the password
+        // does not matter here, there is nothing to
+        // unlock in the first place.
+        (false, _, 0) => AuthorizationAction::NoCredentials,
 
         // no other key, no password
         // and but one credential
         // skip ui, send the cerds directly
         (false, true, 1) => AuthorizationAction::UseOnlyPasskey,
 
-        // another key, no password,
-        // but either no or single cerd
+        // another key, but either no or single cerd
         // the user intent is probably to use
         // either security key or use passkeyd
-        // so, presence to reduce ambiguity
-        (true, true, 0..=1) => AuthorizationAction::Presence,
+        // so, presence to reduce ambiguity.
+        // with no cerd of ours the password does not
+        // matter either, presence still lets the user
+        // reach for the external key.
+        (true, _, 0) => AuthorizationAction::Presence,
+        (true, true, 1) => AuthorizationAction::Presence,
 
         // If no another key, no password, there are more than 1 cerds, selection is obviously needed.
         // If another key, has password, aribitray cerds, selection will handle it.
@@ -219,6 +223,10 @@ fn authorize_selection(
     rp_entity: &PublicKeyCredentialRpEntity,
     passkeys: &[Passkey],
 ) -> anyhow::Result<usize> {
+    if passkeys.is_empty() {
+        anyhow::bail!(CtapStatus::NoCredentials);
+    }
+
     let ui_state = SelectUI {
         rp: rp_entity,
         other_uis: passkeys
@@ -629,4 +637,78 @@ fn get_username_from_uid(uid: libc::uid_t) -> Option<String> {
     let passwd = unsafe { passwd.assume_init() };
     let cstr = unsafe { std::ffi::CStr::from_ptr(passwd.pw_name) };
     cstr.to_str().ok().map(|username| username.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// An empty credential list must never reach the selection UI: its index
+    /// would come back as 0 and `swap_remove(0)` on the empty `Vec` in `get()`
+    /// aborts the whole daemon. This used to happen for every relying party
+    /// sending an `allowCredentials` we hold no passkey for, github.com among
+    /// them, whenever a password was configured.
+    #[test]
+    fn no_credentials_never_selects() {
+        for &has_another_fido_dev in &[false, true] {
+            for &no_pass in &[false, true] {
+                let action = authorization_action(has_another_fido_dev, no_pass, 0);
+
+                assert!(
+                    !matches!(action, AuthorizationAction::Selection),
+                    "empty passkey list routed to the selection UI \
+                     (has_another_fido_dev: {has_another_fido_dev}, no_pass: {no_pass})"
+                );
+            }
+        }
+    }
+
+    /// Without another key around there is nothing to disambiguate, so an empty
+    /// list is answered straight away rather than prompting the user.
+    #[test]
+    fn no_credentials_and_no_other_key_answers_directly() {
+        for &no_pass in &[false, true] {
+            assert!(matches!(
+                authorization_action(false, no_pass, 0),
+                AuthorizationAction::NoCredentials
+            ));
+        }
+    }
+
+    /// With another key present the presence prompt is kept even when we hold
+    /// no passkey, so the user can still reach for the external key.
+    #[test]
+    fn no_credentials_with_another_key_asks_for_presence() {
+        for &no_pass in &[false, true] {
+            assert!(matches!(
+                authorization_action(true, no_pass, 0),
+                AuthorizationAction::Presence
+            ));
+        }
+    }
+
+    /// Behaviour for the non-empty cases is unchanged.
+    #[test]
+    fn existing_credentials_keep_their_action() {
+        assert!(matches!(
+            authorization_action(false, true, 1),
+            AuthorizationAction::UseOnlyPasskey
+        ));
+        assert!(matches!(
+            authorization_action(true, true, 1),
+            AuthorizationAction::Presence
+        ));
+        assert!(matches!(
+            authorization_action(false, false, 1),
+            AuthorizationAction::Selection
+        ));
+        assert!(matches!(
+            authorization_action(true, false, 1),
+            AuthorizationAction::Selection
+        ));
+        assert!(matches!(
+            authorization_action(false, true, 2),
+            AuthorizationAction::Selection
+        ));
+    }
 }


### PR DESCRIPTION
## The crash

With a password configured (`NO_PASS` unset), any `getAssertion` for a relying party we hold no matching passkey for takes the daemon down:

```
thread 'main' panicked at library/alloc/src/vec/mod.rs:2265:13:
swap_remove index (is 0) should be < len (is 0)
systemd[1]: passkeyd.service: Main process exited, code=dumped, status=6/ABRT
```

## Why

`authorization_action()` maps an empty credential list to `NoCredentials` only in the `(false, true, 0)` arm — that is, exclusively when `no_pass` is set:

```rust
(false, true, 0) => AuthorizationAction::NoCredentials,
```

With a password configured the very same empty list falls through to `_ => Selection`. `authorize_selection()` then spawns the selection UI over an empty list and returns index 0 — unlike `authorize_presence()`, which does guard for this case. Back in `get()` that index reaches

```rust
let authorized_passkey = passkeys.swap_remove(ui_response.index);
```

on an empty `Vec`, and the daemon aborts.

## Impact

This fires on every relying party that sends a non-empty `allowCredentials` the user has no passkey for. github.com does exactly that when it confirms access before enrolling a new passkey, so passkeyd core-dumps mid-request, the browser sees the authenticator drop off the bus, and enrollment can never complete — the user is bounced back to a password prompt. `Restart=on-failure` masks it as a puzzling reconnect rather than an obvious failure.

Sites that send no allow list are unaffected, webauthn.io among them, which makes this easy to miss when testing.

Observed on 1.9.2, reproducible on `main`.

## The fix

Decide `NoCredentials` on the credential count alone, and keep the presence prompt for `(true, _, 0)` so the user can still reach for an external key when one is present. Only the two previously panicking combinations change behaviour:

| `has_another_fido_dev` | `no_pass` | count | before | after |
| --- | --- | --- | --- | --- |
| false | false | 0 | `Selection` → **panic** | `NoCredentials` |
| true | false | 0 | `Selection` → **panic** | `Presence` |

Every other combination is left as it was. `authorize_selection()` also gets the empty-list guard that `authorize_presence()` already has, so the panicking path is closed off even if a future arm routes an empty list there again.

## Tests

Added unit tests over the `authorization_action()` matrix. Against the unpatched function three of them fail, naming the combination:

```
empty passkey list routed to the selection UI (has_another_fido_dev: false, no_pass: false)
```

`existing_credentials_keep_their_action` passes both before and after, covering the claim that the non-empty cases are untouched.

`cargo test -p passkeyd --bin passkeyd` — 6 passed, 0 failed.

Note on the rest of the workspace: `passkeyd-gtk-enroll`'s `test_enrollment_process` fails for me with exit 203, but it does so independently of this change — it launches the real UI through `systemd-run --machine=1000@ --user` and depends only on `passkeyd-abi` and `passkeyd-locale`, neither of which is touched here.
